### PR TITLE
fix: grant heimdallr job required issues and pull-requests permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,9 @@ jobs:
   heimdallr:
     needs: release
     uses: "Mosher-Labs/.github/.github/workflows/heimdallr.yml@main"
-    permissions: read-all
+    permissions:
+      issues: write
+      pull-requests: write
     secrets: inherit
     with:
       slack_message: "The project <https://github.com/${{ github.repository }}|${{ github.repository }}> just released version <https://github.com/${{ github.repository }}/releases/tag/${{ needs.release.outputs.next_version }}|${{ needs.release.outputs.next_version }}>."


### PR DESCRIPTION
## Summary

- Add `issues: write` and `pull-requests: write` permissions to the `heimdallr` job

The reusable `heimdallr.yml` workflow requires these permissions but the calling workflow only granted `read-all`, which doesn't include write access. This caused the workflow validation error after the Renovate update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)