### PR TITLE
feat: add PR version preview comment via heimdallr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   release:
@@ -18,4 +21,8 @@ jobs:
       pull-requests: write
     secrets: inherit
     with:
+      enable_slack: ${{ github.event_name != 'pull_request' }}
+      enable_comment_on_pr: ${{ github.event_name == 'pull_request' }}
+      comment_identifier: "<!-- heimdallr_release_version_comment -->"
+      comment_content: "## :rocket: Next Release Version\n\nThe next semantic version for this PR will be: **${{ needs.release.outputs.next_version }}**"
       slack_message: "The project <https://github.com/${{ github.repository }}|${{ github.repository }}> just released version <https://github.com/${{ github.repository }}/releases/tag/${{ needs.release.outputs.next_version }}|${{ needs.release.outputs.next_version }}>."


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to the release workflow
- Enable `enable_comment_on_pr` on PRs so heimdallr posts the predicted next semantic version as a PR comment
- Enable Slack notification only on push to main (not PRs)

Every PR will now get a comment like:
> ## 🚀 Next Release Version
> The next semantic version for this PR will be: **v1.2.3**

This lets you verify the version bump (major/minor/patch) matches your intent before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)