### PR TITLE
feat: add netlify.toml with NODE_VERSION and Renovate custom manager

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "bundle install && bundle exec jekyll build && npm run workbox generateSW workbox-config.js"
+
+[build.environment]
+  RUBY_VERSION = "4.0.5"
+  NODE_VERSION = "25.9.0"

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,17 @@
       "@benniemosher"
     ]
   },
+  "customManagers": [
+    {
+      "description": "Keep NODE_VERSION in netlify.toml in sync with .node-version",
+      "customType": "regex",
+      "fileMatch": ["netlify\\.toml"],
+      "matchStrings": ["NODE_VERSION = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
   "packageRules": [
     {
       "description": "GitHub Actions - automerge patch/minor",


### PR DESCRIPTION
Adds `netlify.toml` to pin Ruby and Node versions for Netlify builds. Also adds a Renovate custom manager so future node version bumps update both `.node-version` and `netlify.toml` in the same PR.