### PR TITLE
feat: add spoiler warning modal for book reviews

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,51 @@
+version: "3"
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+
+  serve:
+    desc: Start Jekyll dev server at http://localhost:4000 (foreground, with logs)
+    cmds:
+      - docker compose up
+
+  dev:
+    desc: Start Jekyll in background, wait until ready, then open browser
+    cmds:
+      - docker compose up -d
+      - cmd: until curl -sf http://localhost:4000 > /dev/null; do sleep 2; done
+        ignore_error: true
+      - open http://localhost:4000
+      - docker compose logs -f
+
+  open:
+    desc: Open the dev site in the browser
+    cmds:
+      - open http://localhost:4000
+
+  stop:
+    desc: Stop the dev server
+    cmds:
+      - docker compose down
+
+  build:
+    desc: Build the site for production (mirrors netlify.toml)
+    cmds:
+      - docker compose run --rm --no-deps jekyll bash -c "bundle install && bundle exec jekyll build"
+
+  lint:css:
+    desc: Lint SCSS files with stylelint
+    cmds:
+      - npx stylelint "**/*.scss"
+
+  lint:
+    desc: Run all linters
+    deps: [lint:css]
+
+  clean:
+    desc: Remove built site, Jekyll cache, and Docker volume cache
+    cmds:
+      - rm -rf _site .jekyll-cache
+      - docker compose down -v

--- a/_config.yml
+++ b/_config.yml
@@ -42,4 +42,14 @@ jekyll-minifier:
 feed:
   tags: false
 
+spoiler_warning:
+  enabled: true
+  categories:
+    - book
+    - reviews
+  title: "Spoiler Warning"
+  message: "This post contains spoilers for the book being reviewed. If you haven't read it yet and want to go in fresh, you may want to skip this one."
+  confirm_text: "Continue Reading"
+  cancel_text: "← Go Back"
+
 include: [_redirects]

--- a/_includes/spoiler-modal.html
+++ b/_includes/spoiler-modal.html
@@ -1,0 +1,32 @@
+{%- if page.spoiler_warning -%}
+{%- assign sw = site.spoiler_warning -%}
+{%- assign sw_key = page.url | replace: '/', '_' -%}
+<div
+  id="spoiler-warning-modal"
+  class="sw-modal"
+  data-post-key="{{ sw_key }}"
+  data-home-url="{{ '/' | prepend: site.baseurl }}"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="sw-modal-title"
+>
+  <div class="sw-modal__card">
+    <div class="sw-modal__icon" aria-hidden="true">&#9888;</div>
+    <h2 id="sw-modal-title" class="sw-modal__title">
+      {{ sw.title | default: "Spoiler Warning" }}
+    </h2>
+    <p class="sw-modal__message">
+      {{ sw.message | default: "This post contains spoilers for the book being reviewed." }}
+    </p>
+    <div class="sw-modal__actions">
+      <button id="sw-modal-cancel" class="sw-modal__btn sw-modal__btn--cancel" type="button">
+        {{ sw.cancel_text | default: "&larr; Go Back" }}
+      </button>
+      <button id="sw-modal-accept" class="sw-modal__btn sw-modal__btn--accept" type="button">
+        {{ sw.confirm_text | default: "Continue Reading" }}
+      </button>
+    </div>
+  </div>
+</div>
+<script src="{{ '/assets/js/spoiler-warning.js' | prepend: site.baseurl }}"></script>
+{%- endif -%}

--- a/_includes/spoiler-modal.html
+++ b/_includes/spoiler-modal.html
@@ -5,7 +5,6 @@
   id="spoiler-warning-modal"
   class="sw-modal"
   data-post-key="{{ sw_key }}"
-  data-home-url="{{ '/' | prepend: site.baseurl }}"
   role="dialog"
   aria-modal="true"
   aria-labelledby="sw-modal-title"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,6 +3,8 @@ layout: default
 ---
 {%- assign date_format = site.date_format | default: "%b %-d, %Y" -%}
 
+{%- include spoiler-modal.html -%}
+
 <main>
   <article>
     <h2>

--- a/_plugins/jekyll-spoiler-warning.rb
+++ b/_plugins/jekyll-spoiler-warning.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Jekyll
+  # Automatically flags posts as containing spoilers based on categories/tags
+  # configured under `spoiler_warning:` in _config.yml. Posts can also be
+  # explicitly opted in or out via `spoiler_warning: true/false` in front matter.
+  #
+  # _config.yml example:
+  #   spoiler_warning:
+  #     enabled: true
+  #     categories:
+  #       - book
+  #       - reviews
+  #     tags:
+  #       - spoilers
+  #     title: "Spoiler Warning"
+  #     message: "This post contains spoilers."
+  #     confirm_text: "Continue Reading"
+  #     cancel_text: "← Go Back"
+  #
+  # To package as a gem: move this file into lib/jekyll-spoiler-warning.rb,
+  # add require in a plugins/ entry point, and ship _includes/spoiler-modal.html
+  # + assets/js/spoiler-warning.js as documented copy steps in your README.
+  class SpoilerWarningGenerator < Generator
+    safe true
+    priority :normal
+
+    def generate(site)
+      config = site.config["spoiler_warning"] || {}
+      return if config["enabled"] == false
+
+      trigger_categories = normalize(config["categories"])
+      trigger_tags = normalize(config["tags"])
+
+      site.posts.docs.each do |post|
+        next if post.data["spoiler_warning"] == false
+
+        already_flagged = post.data["spoiler_warning"] == true
+        post_cats = normalize(post.data["categories"])
+        post_tags = normalize(post.data["tags"])
+
+        matches = already_flagged ||
+                  intersects?(post_cats, trigger_categories) ||
+                  intersects?(post_tags, trigger_tags)
+
+        post.data["spoiler_warning"] = matches
+      end
+    end
+
+    private
+
+    def normalize(values)
+      Array(values).map(&:to_s).map(&:downcase)
+    end
+
+    def intersects?(a, b)
+      !(a & b).empty?
+    end
+  end
+end

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -9,20 +9,31 @@ footer {
     margin: 0;
 
     @media only screen and (max-width: 768px) {
-      margin: 0 40px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      width: 100%;
+      gap: 0.5rem;
     }
   }
 
   a.berserker {
     display: inline-flex;
-    justify-content: center;
     align-items: center;
     white-space: nowrap;
     font-weight: 400;
-    border-left: 1px solid #ececec;
     margin-left: 1rem;
-    padding-left: 1rem;
-    box-sizing: border-box;
+    gap: 1rem;
+
+    &::before {
+      content: '';
+      display: block;
+      width: 1px;
+      height: 1em;
+      background-color: #ececec;
+      flex-shrink: 0;
+    }
 
     span {
       margin-right: 1rem;
@@ -32,6 +43,14 @@ footer {
       display: inline-block;
       height: 100%;
       max-height: 25px;
+    }
+
+    @media only screen and (max-width: 768px) {
+      margin-left: 0;
+
+      &::before {
+        display: none;
+      }
     }
   }
 
@@ -43,5 +62,9 @@ footer {
   }
   @media only screen and (min-width: 1024px) {
     max-width: 80%;
+  }
+
+  @media only screen and (max-width: 768px) {
+    justify-content: center;
   }
 }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -13,7 +13,19 @@ article {
   }
 
   @media only screen and (max-width: 768px) {
-    margin: 40px 40px 0;
+    margin: 40px 5% 0;
+
+    ul,
+    ol {
+      padding-left: 1.25em;
+    }
+
+    img {
+      display: block;
+      float: none !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+    }
   }
 
   .read-more {

--- a/_sass/_spoiler-modal.scss
+++ b/_sass/_spoiler-modal.scss
@@ -1,0 +1,99 @@
+@use "sass:color";
+@use "variables";
+
+.sw-modal {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(variables.$primary-color, 0.94);
+  padding: 1rem;
+
+  &__card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2.5rem 2rem;
+    max-width: 480px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  }
+
+  &__icon {
+    font-size: 2.5rem;
+    line-height: 1;
+    margin-bottom: 1rem;
+    display: block;
+    color: variables.$secondary-color;
+  }
+
+  &__title {
+    font-family: Merriweather, serif;
+    color: variables.$primary-color;
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 1rem;
+    max-width: none;
+    letter-spacing: -0.01em;
+  }
+
+  &__message {
+    color: #4c566a;
+    line-height: 1.6;
+    margin: 0 0 2rem;
+    max-width: none;
+    font-size: 0.95rem;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  &__btn {
+    font-family: Raleway, sans-serif;
+    font-weight: 600;
+    font-size: 0.875rem;
+    padding: 0.7rem 1.4rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.15s ease-in-out;
+    border: 2px solid variables.$secondary-color;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+
+    &--accept {
+      background: variables.$secondary-color;
+      color: variables.$primary-color;
+
+      &:hover,
+      &:focus {
+        background: color.adjust(variables.$secondary-color, $lightness: -10%);
+        border-color: color.adjust(variables.$secondary-color, $lightness: -10%);
+        outline: none;
+      }
+    }
+
+    &--cancel {
+      background: transparent;
+      color: variables.$primary-color;
+
+      &:hover,
+      &:focus {
+        background: color.adjust(variables.$primary-color, $lightness: 60%);
+        outline: none;
+      }
+    }
+  }
+}
+
+body.sw-open {
+  overflow: hidden;
+}

--- a/assets/css/me.scss
+++ b/assets/css/me.scss
@@ -10,3 +10,4 @@
 @use "main";
 @use "post";
 @use "footer";
+@use "spoiler-modal";

--- a/assets/js/spoiler-warning.js
+++ b/assets/js/spoiler-warning.js
@@ -1,0 +1,33 @@
+(function () {
+  var modal = document.getElementById('spoiler-warning-modal');
+  if (!modal) return;
+
+  var postKey = modal.getAttribute('data-post-key');
+  var homeUrl = modal.getAttribute('data-home-url') || '/';
+  var storageKey = 'sw_accepted' + postKey;
+
+  // Already accepted — remove modal immediately so content is visible
+  if (localStorage.getItem(storageKey)) {
+    modal.parentNode.removeChild(modal);
+    return;
+  }
+
+  document.body.classList.add('sw-open');
+
+  document.getElementById('sw-modal-accept').addEventListener('click', function () {
+    localStorage.setItem(storageKey, '1');
+    document.body.classList.remove('sw-open');
+    modal.parentNode.removeChild(modal);
+  });
+
+  document.getElementById('sw-modal-cancel').addEventListener('click', function () {
+    window.location.href = homeUrl;
+  });
+
+  // Allow Escape key to trigger cancel
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      window.location.href = homeUrl;
+    }
+  });
+}());

--- a/assets/js/spoiler-warning.js
+++ b/assets/js/spoiler-warning.js
@@ -3,7 +3,8 @@
   if (!modal) return;
 
   var postKey = modal.getAttribute('data-post-key');
-  var homeUrl = modal.getAttribute('data-home-url') || '/';
+  var rawUrl = modal.getAttribute('data-home-url') || '/';
+  var homeUrl = /^\/[^/\\]/.test(rawUrl) || rawUrl === '/' ? rawUrl : '/';
   var storageKey = 'sw_accepted' + postKey;
 
   // Already accepted — remove modal immediately so content is visible

--- a/assets/js/spoiler-warning.js
+++ b/assets/js/spoiler-warning.js
@@ -1,22 +1,8 @@
 (function () {
-  function safeUrl(url, fallback) {
-    try {
-      var parsed = new URL(url, window.location.origin);
-      if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
-          parsed.origin !== window.location.origin) {
-        return fallback;
-      }
-      return parsed.pathname + parsed.search + parsed.hash;
-    } catch (e) {
-      return fallback;
-    }
-  }
-
   var modal = document.getElementById('spoiler-warning-modal');
   if (!modal) return;
 
   var postKey = modal.getAttribute('data-post-key');
-  var homeUrl = safeUrl(modal.getAttribute('data-home-url') || '/', '/');
   var storageKey = 'sw_accepted' + postKey;
 
   // Already accepted — remove modal immediately so content is visible
@@ -34,13 +20,13 @@
   });
 
   document.getElementById('sw-modal-cancel').addEventListener('click', function () {
-    window.location.href = homeUrl;
+    window.location.replace('/');
   });
 
   // Allow Escape key to trigger cancel
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
-      window.location.href = homeUrl;
+      window.location.replace('/');
     }
   });
 }());

--- a/assets/js/spoiler-warning.js
+++ b/assets/js/spoiler-warning.js
@@ -1,10 +1,22 @@
 (function () {
+  function safeUrl(url, fallback) {
+    try {
+      var parsed = new URL(url, window.location.origin);
+      if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+          parsed.origin !== window.location.origin) {
+        return fallback;
+      }
+      return parsed.pathname + parsed.search + parsed.hash;
+    } catch (e) {
+      return fallback;
+    }
+  }
+
   var modal = document.getElementById('spoiler-warning-modal');
   if (!modal) return;
 
   var postKey = modal.getAttribute('data-post-key');
-  var rawUrl = modal.getAttribute('data-home-url') || '/';
-  var homeUrl = /^\/[^/\\]/.test(rawUrl) || rawUrl === '/' ? rawUrl : '/';
+  var homeUrl = safeUrl(modal.getAttribute('data-home-url') || '/', '/');
   var storageKey = 'sw_accepted' + postKey;
 
   // Already accepted — remove modal immediately so content is visible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  jekyll:
+    image: ruby:4.0-slim
+    working_dir: /site
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/site
+      - bundle_cache:/usr/local/bundle
+    environment:
+      - JEKYLL_ENV=development
+    command: >
+      bash -c "
+        apt-get update -qq &&
+        apt-get install -y --no-install-recommends build-essential git &&
+        bundle install &&
+        bundle exec jekyll serve --host 0.0.0.0 --livereload --force_polling
+      "
+
+volumes:
+  bundle_cache:


### PR DESCRIPTION
## Summary

- Adds a spoiler warning modal to all book review posts (`categories: [book, reviews]`), auto-detected by a Jekyll generator plugin — no per-post front matter needed
- localStorage remembers acceptance per post; returning visitors skip the modal; clearing browser storage resets it
- Cancel button navigates home; Escape key also triggers cancel
- Adds `Taskfile.yml` (`task serve`, `task dev`, `task build`, `task lint`, `task stop`, `task clean`) and `docker-compose.yml` using `ruby:4.0-slim` for local dev without needing Ruby on the host

## Mobile layout fixes

- Book cover images: clears inline `float: right` on narrow screens so images stack full-width instead of creating a 30px text corridor
- Article side margins scaled to `5%` (proportional vs fixed `40px`)
- List `padding-left` reduced to `1.25em` to align bullet text with paragraph text

## Footer fixes

- Mobile: both copyright and attribution lines horizontally centered
- Desktop: divider line replaced with a `::before` flex item at explicit `1em` height — proportional to text rather than spanning the full element height

## Test plan

- [x] Visit a book review — spoiler modal appears
- [x] Click "Continue Reading" — modal dismisses, post is readable
- [x] Navigate away and back — modal does not reappear
- [x] Clear localStorage (`localStorage.clear()` in console) and revisit — modal reappears
- [x] Click "← Go Back" or press Escape — navigates to home page
- [x] Check mobile layout: images stack, list items align, footer centered
- [x] Check desktop footer: divider line height matches text

🤖 Generated with [Claude Code](https://claude.com/claude-code)